### PR TITLE
Fix gem summary

### DIFF
--- a/blueprinter-activerecord.gemspec
+++ b/blueprinter-activerecord.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Procore Technologies, Inc.']
   spec.email = ['opensource@procore.com']
 
-  spec.summary = 'Extensions for using ActiveRecord with ActiveRecord'
+  spec.summary = 'Extensions for using Blueprinter with ActiveRecord'
   spec.description = 'Eager loading and other ActiveRecord helpers for Blueprinter'
   spec.homepage = 'https://github.com/procore-oss/blueprinter-activerecord'
   spec.license = 'MIT'

--- a/lib/blueprinter-activerecord/version.rb
+++ b/lib/blueprinter-activerecord/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlueprinterActiveRecord
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
![image](https://github.com/procore-oss/blueprinter-activerecord/assets/81826/289b162e-61ac-4e2a-a2ee-bbab7386a1e6)

Probably not worth a new release, but at least it will get fixed next time.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [x] My build is green