### PR TITLE
chore: simplify release GitHub Action

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,66 @@
+name: 🐞 Bug
+description: File a bug/issue
+title: "[bug] <title>"
+labels: [bug, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: checkboxes
+  attributes:
+    label: Is this a regression?
+    description: Did this behavior work before?
+    options:
+    - label: Yes, this used to work before
+      required: false
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1.
+      2.
+      3.
+      4.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: OSX 13.3.1
+        - **Browser Name and Version**: Chrome Version 112.0.5615.49 (Official Build) (arm64)
+        - **Ruby Version**: 3.0.0
+    value: |
+        - OS:
+        - Browser Name and version:
+        - Ruby Version:
+    render: markdown
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/ISSUE_TEMPLATE/docs.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,18 @@
+name: 📚 Documentation or README.md issue report
+description: File a bug/issue for docs or README.md
+title: "[bug] <title>"
+labels: [docs, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Docs/README.md Part to update
+    description: A concise description of what you thing should be updated
+  validations:
+    required: true

--- a/.github/workflows/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,36 @@
+name: 🚀🆕 Feature Request
+description: Suggest an idea or possible new feature for this project
+title: "[Feature Request] <title>"
+labels: [feature, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem? Please describe
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the feature you'd like to see implemented
+    description: A clear and concise description of what you want to happen
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any other context or additional information about the problem here
+  validations:
+    required: false

--- a/.github/workflows/ISSUE_TEMPLATE/question-support.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/question-support.yml
@@ -1,0 +1,18 @@
+name: ❓ Question or Support Request
+description: Questions and requests for support
+title: "[Question/Support] <title>"
+labels: [question, support, needs-triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Describe your question or ask for support
+    description: A concise description of what you would like support with
+  validations:
+    required: true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,43 @@
+name: "Custom CodeQL"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: Ubuntu-latest
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'ruby' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,35 +6,38 @@ on:
     branches: [main]
   workflow_dispatch: # allow manual deployment through GitHub Action UI
 jobs:
-  release:
+  version-check:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      changed: ${{ steps.check.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
-      - name: Version file changed
-        id: version-file-changed
+      - name: Check if version has been updated
+        id: check
         uses: tj-actions/changed-files@v42
         with:
           files: lib/blueprinter-activerecord/version.rb
+  release:
+    runs-on: ubuntu-latest
+    needs: version-check
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up Ruby
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
           bundler-cache: true
       - name: Installing dependencies
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
       - name: Build gem file
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         run: bundle exec rake build
       - uses: fac/ruby-gem-setup-credentials-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         with:
           user: ""
           key: rubygems
           token: ${{secrets.RUBY_GEMS_API_KEY}}
       - uses: fac/ruby-gem-push-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         with:
           key: rubygems


### PR DESCRIPTION
Move version file change check to its own job
allows us to simplify conditional checks to one
in other steps since they will be under their own
job now

- [x] Add GitHub Issue Templates
- [x] Add CodeQL GitHub Action for Ruby

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
