### PR TITLE
chore: drop support for ruby 2.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.0', '3.1', '3.2']
-        include:
-          - os: ubuntu-20.04
-            ruby: '2.7'
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Ruby versions that are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| <=2.6   | :x:                |
-| 2.7     | :white_check_mark: |
+| <=2.7   | :x:                |
 | 3.0     | :white_check_mark: |
 | 3.1     | :white_check_mark: |
 | 3.2     | :white_check_mark: |
+| 3.3     | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/blueprinter-activerecord.gemspec
+++ b/blueprinter-activerecord.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Eager loading and other ActiveRecord helpers for Blueprinter'
   spec.homepage = 'https://github.com/procore-oss/blueprinter-activerecord'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/procore-oss/blueprinter-activerecord'


### PR DESCRIPTION
- [x] change minimum ruby to 3.0
- [x] update all files related to versions

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
