### PR TITLE
Merge and replace multiple preloads ourselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,11 @@
-### 0.5.0 (2024-01-26)
+## 1.0.2 (?)
 
-* Adds an "auto" mode that automatically preloads every Blueprint-rendered query
-* Adds a "dynamic" mode that allows a single block to decide which Blueprint-rendered queries get preloaded
-* Adds two logging extensions for gathering preload stats before and after implementing the Preloader extension
+- [BUGFIX] Fixes issue where ActiveRecord sometimes doesn't correctly merge Blueprinter-derived preloads with manually added preloads, resulting in dropped preloads and worse performance.
 
-### 0.4.0 (2024-01-18)
+## 1.0.1 (2024-02-09)
 
-* Remove the Blueprinter reflection and extension stubs
-* Require Blueprinter >= 1.0
+- Fixed typo in gemspec
 
-### 0.3.1 (2023-12-04)
+## 1.0.0 (2024-02-09)
 
-* Switches to a real Blueprinter Extension
-* Autodetects Blueprinter and view on render
-* Allows using `:includes` or `:eager_load` instead of `:preload`
-
-### 0.1.3 (2023-10-16)
-
-* [BUGFIX] Stop preloading when we hit a dynamic blueprint
-
-### 0.1.2 (2023-10-03)
-
-* [BUGFIX] Associations from included views were being missed
-
-### 0.1.1 (2023-09-29)
-
-* [BUGFIX] Open up to all 0.x blueprinter versions
-
-### 0.1.0 (2023-09-25)
-
-* [BUGFIX] Associations weren't being found if they used a custom name (e.g. `association :widget, blueprint: WidgetBlueprint, name: :wdgt`)
-
-## 0.0.1 (2023-09-20)
-
-* Initial release
+- Initial release

--- a/lib/blueprinter-activerecord/preloader.rb
+++ b/lib/blueprinter-activerecord/preloader.rb
@@ -41,8 +41,9 @@ module BlueprinterActiveRecord
         if object.preload_blueprint_method || auto || auto_proc&.call(object, blueprint, view, options) == true
           object.before_preload_blueprint = extract_preloads object
           blueprint_preloads = self.class.preloads(blueprint, view, object.model)
+          unified_preloads = merge_values([*object.values[use], blueprint_preloads])
           loader = object.preload_blueprint_method || use
-          object.public_send(loader, blueprint_preloads)
+          object.except(loader).public_send(loader, unified_preloads)
         else
           object
         end

--- a/lib/blueprinter-activerecord/query_methods.rb
+++ b/lib/blueprinter-activerecord/query_methods.rb
@@ -43,8 +43,9 @@ module BlueprinterActiveRecord
 
       if blueprint and view
         # preload right now
-        preloads = Preloader.preloads(blueprint, view, model)
-        public_send(use, preloads)
+        blueprint_preloads = Preloader.preloads(blueprint, view, model)
+        unified_preloads = Helpers.merge_values([*values[use], blueprint_preloads])
+        except(use).public_send(use, unified_preloads)
       else
         # preload during render
         @values[:preload_blueprint_method] = use

--- a/lib/blueprinter-activerecord/version.rb
+++ b/lib/blueprinter-activerecord/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlueprinterActiveRecord
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/test/preloader_extension_test.rb
+++ b/test/preloader_extension_test.rb
@@ -108,6 +108,17 @@ class PreloaderExtensionTest < Minitest::Test
     assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
+  def test_blueprinter_preload_now_with_existing_preloads
+    q = Widget.
+      where("widgets.name <> ?", "Widget C").
+      order(:name).
+      preload({battery1: :refurb_plan}).
+      preload_blueprint(WidgetBlueprint, :no_power).
+      strict_loading
+
+    assert_equal [{:battery1=>{:refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+  end
+
   def test_auto_preload
     ext = BlueprinterActiveRecord::Preloader.new(auto: true)
     q = Widget.
@@ -119,6 +130,20 @@ class PreloaderExtensionTest < Minitest::Test
     assert ext.auto
     assert_equal :preload, ext.use
     assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+  end
+
+  def test_auto_preload_with_existing_preloads
+    ext = BlueprinterActiveRecord::Preloader.new(auto: true)
+    q = Widget.
+      where("name <> ?", "Widget C").
+      order(:name).
+      preload({battery1: :refurb_plan}).
+      strict_loading
+    q = ext.pre_render(q, WidgetBlueprint, :no_power, {})
+
+    assert ext.auto
+    assert_equal :preload, ext.use
+    assert_equal [{:battery1=>{:refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
   def test_auto_preload_with_block_true


### PR DESCRIPTION
Rails is *supposed* to handle things gracefully when one set of preloads is layered on top of another (e.g. when a Blueprinter's preloads are added to a query with existing preloads). We even have tests for it. But we're getting reports it may not be working in some cases - that sometimes the original, manually added preloads get (partially??) wiped out.

I haven't been able to duplicate it. But this PR would remove all ambiguity. Every time a Blueprint's preloads are added, they're [merged into](https://github.com/procore-oss/blueprinter-activerecord/blob/493f1d8962ef9e20a710733e2ffe4ce549f0592f/lib/blueprinter-activerecord/helpers.rb#L48) the existing preloads, instead of being added as a separate preload entry for Rails to deal with.

Has been tested against real-world preloads + autopreloads to ensure they merge as expected. Includes a version bump since this is a critical bugfix.