### PR TITLE
chore: change github actions from tags to SHAs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,15 +1,12 @@
 name: "Custom CodeQL"
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
+    branches: ["main"]
 permissions:
   contents: read
-
 jobs:
   analyze:
     name: Analyze
@@ -19,25 +16,20 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'ruby' ]
-
+        language: ['ruby']
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Check if version has been updated
         id: check
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@20576b4b9ed46d41e2d45a2256e5e2316dde6834 # v43
         with:
           files: lib/blueprinter-activerecord/version.rb
   release:
@@ -23,9 +23,9 @@ jobs:
     needs: version-check
     if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
         with:
           ruby-version: 3.2
           bundler-cache: true
@@ -33,11 +33,11 @@ jobs:
         run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
       - name: Build gem file
         run: bundle exec rake build
-      - uses: fac/ruby-gem-setup-credentials-action@v2
+      - uses: fac/ruby-gem-setup-credentials-action@5f62d5f2f56a11c7422a92f81fbb29af01e1c00f # v2
         with:
           user: ""
           key: rubygems
           token: ${{secrets.RUBY_GEMS_API_KEY}}
-      - uses: fac/ruby-gem-push-action@v2
+      - uses: fac/ruby-gem-push-action@81d77bf568ff6659d7fae0f0c5a036bb0aeacb1a # v2
         with:
           key: rubygems

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,10 +7,8 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *' # https://crontab.guru/#30_1_*_*_* (everyday at 0130)
-
 permissions:
   contents: read
-
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -18,19 +16,21 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            This issue is stale because it has been open for 30 days with no activity
-            and will be closed in 14 days unless you add a comment.
+            This issue is stale because it has been open for 30 days with no activity and will be closed in 14 days unless you add a comment.
+
           stale-pr-message: >
-            This PR is stale because it has been open for 30 days with no activity
-            and will be closed in 14 days unless you add a comment.
+            This PR is stale because it has been open for 30 days with no activity and will be closed in 14 days unless you add a comment.
+
           close-issue-message: >
             This issue was closed because it has been stalled for 14 days with no activity.
+
           close-pr-message: >
             This PR was closed because it has been stalled for 14 days with no activity.
+
           days-before-issue-stale: 30
           days-before-pr-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,9 @@ jobs:
         ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
It is more secure.  SHAs can't change out from underneath you, tags can

- [x] change GitHub Actions to use SHAs instead of tags
  - Why?
    - To prevent supply chain attack. Tags can move. They are mutable. SHAs are not.
  - used [frizbee](https://github.com/stacklok/frizbee) - ran `frizbee ghactions -d .github/workflows` locally - also fixes formatting

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
