### PR TITLE
Allow arbitrary annotated preloads on fields and associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.0 (2024-06-10)
+- [FEATURE] Ability to annotate a field or association for extra preloads (e.g. `field :category_name, preload: :category`)
+
 ### 1.0.2 (2024-05-21)
 
 - [BUGFIX] Fixes a potentially significant performance issue with `auto`. See https://github.com/procore-oss/blueprinter-activerecord/pull/16.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,46 @@ If you'd prefer to use `includes` or `eager_load` rather than `preload`, pass th
   preload_blueprint(use: :includes)
 ```
 
+## Annotations
+
+Some associations may be "hidden" inside methods or field blocks, requiring you to annotate your Blueprints.
+
+```ruby
+# Here is a model with some instance methods
+class Widget < ActiveRecord::Base
+  belongs_to :category
+  belongs_to :project
+  has_many :parts
+
+  # Blueprinter can't see what this method is calling
+  def parts_description
+    # I'm calling the "parts" association, but the caller won't know!
+    parts.map(&:description).join(", ")
+  end
+
+  # Or this one
+  def owner_address
+    project.owner ? project.owner.address.to_s : project.company.address
+  end
+end
+
+# Here's a Blueprint with one association, two annotated fields, and one annotated association
+class WidgetBlueprint < Blueprinter::Base
+  association :category, blueprint: CategoryBlueprint
+
+  # Blueprinter can't see the "parts" association being used here, so we annotate it
+  field :parts_description, preload: :parts
+
+  # Your annotations can be as complex as needed
+  field :owner_address, preload: {project: [:company, {owner: :address}]}
+
+  # You can annotate association blocks, too
+  association :parts, blueprint: PartBlueprint, preload: :draft_parts do |widget|
+    widget.parts + widget.draft_parts
+  end
+end
+```
+
 ## Notes on use
 
 ### Pass the *query* to render, not query *results*
@@ -92,40 +132,14 @@ do_something widgets
 WidgetBlueprint.render(widgets, view: :extended)
 ```
 
-### Look out for hidden associations
+### Use strict_loading to find hidden associations
 
-*blueprinter-activerecord* may feel magical, but it's not magic. Some associations may be "hidden" and you'll need to preload them the old-fashioned way.
+Rails 6.1 added support for `strict_loading`. Depending on your configuration, it will either raise exceptions or log warnings if a query triggers any lazy loading. Very useful for catching "hidden" associations.
 
 ```ruby
-# Here's a Blueprint with one association and one field
-class WidgetBlueprint < Blueprinter::Base
-  association :category, blueprint: CategoryBlueprint
-  field :parts_description
-  ...
-end
-
-class Widget < ActiveRecord::Base
-  belongs_to :category
-  has_many :parts
-
-  # The field is this instance method, and Blueprinter can't see inside it
-  def parts_description
-    # I'm calling the "parts" association but no one knows!
-    parts.map(&:description).join(", ")
-  end
-end
-
-q = Widget.where(...).order(...).
-  # Since "category" is declared in the Blueprint, it will automatically be preloaded during "render".
-  # But because "parts" is hidden inside of a method call, we must manually preload it.
-  preload(:parts).
-  # catch any other hidden associations
-  strict_loading
-
-WidgetBlueprint.render(q)
+widgets = Widget.where(...).strict_loading
+WidgetBlueprint.render(widgets)
 ```
-
-Rails 6.1 added support for `strict_loading`. Depending on your configuration, it will either raise exceptions or log warnings if a query triggers any lazy loading. Very useful for catching any associations Blueprinter can't see.
 
 ## Logging
 

--- a/lib/blueprinter-activerecord/version.rb
+++ b/lib/blueprinter-activerecord/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlueprinterActiveRecord
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/test/preloads_test.rb
+++ b/test/preloads_test.rb
@@ -33,4 +33,42 @@ class PreloadsTest < Minitest::Test
       battery2: {refurb_plan: {}, fake_assoc: {}},
     }, preloads)
   end
+
+  def test_preload_with_annotated_fields
+    blueprint = Class.new(Blueprinter::Base) do
+      association :project, blueprint: ProjectBlueprint
+      field :category_name, preload: :category do |w|
+        w.category.name
+      end
+      field :refurb_plan, preload: {battery1: :refurb_plan} do |w|
+        w.battery1&.refurb_plan&.name
+      end
+    end
+
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, Widget)
+    assert_equal({
+      project: {},
+      category: {},
+      battery1: {refurb_plan: {}},
+    }, preloads)
+  end
+
+  def test_preload_with_annotated_associations
+    blueprint = Class.new(Blueprinter::Base) do
+      association :project, blueprint: ProjectBlueprint
+      association :category_name, blueprint: CategoryBlueprint, preload: :category do |w|
+        w.category.name
+      end
+      association :refurb_plan, blueprint: RefurbPlanBlueprint, preload: {battery1: :refurb_plan} do |w|
+        w.battery1&.refurb_plan&.name
+      end
+    end
+
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, Widget)
+    assert_equal({
+      project: {},
+      category: {},
+      battery1: {refurb_plan: {}},
+    }, preloads)
+  end
 end


### PR DESCRIPTION
One limitation of this extension is Blueprint fields that are model methods (or blocks). Blueprinter can't look into the methods/blocks to see if any associations are being used, allowing "hidden" N+1's to sneak through.

This was noted in the README - that the caller was responsible for manually adding any "hidden" preloads. But this is error-prone, as a Blueprint may be rendered by many callers. With this PR, Blueprint fields and associations may be annotated with additional preloads, DRYing up the callers and removing their need to know about the Blueprint's internals. (Thanks to @ryanmccarthypdx for the suggestion!) Bumps version to 1.1.0.

```ruby
class WidgetBlueprint < Blueprinter::Base
  field :category_name, preload: :category

  # the annotation can be as complex as needed
  field :address, preload: {project: :company} do |widget|
    widget.address || widget.project.address || widget.project.company.address
  end
end
```

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [x] My build is green