### PR TITLE
For recursive or cyclic blueprints, halt after 10 levels by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+### 1.2.0 (2024-06-26)
+
+- [BUGFIX] Fixes an issue where an association wouldn't be preloaded if it used a dynamic blueprint.
+- [BUGFIX] Fixes an infinite loop when [a Blueprint has an association to itself](https://github.com/procore-oss/blueprinter-activerecord/issues/13).
+- Added the `max_recursion` option to customize the new default behavior for recursive/cyclic blueprints.
+- Make `pre_render` compatible with all children of ActiveRecord::Relation ([#28](https://github.com/procore-oss/blueprinter-activerecord/pull/28)).
+
 ### 1.1.0 (2024-06-10)
+
 - [FEATURE] Ability to annotate a field or association for extra preloads (e.g. `field :category_name, preload: :category`)
 
 ### 1.0.2 (2024-05-21)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ class WidgetBlueprint < Blueprinter::Base
 end
 ```
 
+## Recursive Blueprints
+
+Sometimes a model, and its blueprint, will have recursive associations. Think of a nested Category model:
+
+```ruby
+class Category < ApplicationRecord
+  belongs_to :parent, class_name: "Category", optional: true
+  has_many :children, foreign_key: :parent_id, class_name: "Category", inverse_of: :parent
+end
+
+class CategoryBlueprint < Blueprinter::Base
+  field :name
+  association :children, blueprint: CategoryBlueprint
+end
+```
+
+For these kinds of recursive blueprints, the extension will preload up to 10 levels deep by default. If this isn't enough, you can increase it:
+
+```ruby
+association :children, blueprint: CategoryBlueprint, max_recursion: 20
+```
+
 ## Notes on use
 
 ### Pass the *query* to render, not query *results*

--- a/lib/blueprinter-activerecord/added_preloads_logger.rb
+++ b/lib/blueprinter-activerecord/added_preloads_logger.rb
@@ -42,7 +42,7 @@ module BlueprinterActiveRecord
     def pre_render(object, blueprint, view, options)
       if object.is_a?(ActiveRecord::Relation) && object.before_preload_blueprint
         from_code = object.before_preload_blueprint
-        from_blueprint = Preloader.preloads(blueprint, view, object.model)
+        from_blueprint = Preloader.preloads(blueprint, view, model: object.model)
         info = PreloadInfo.new(object, from_code, from_blueprint, caller)
         @log_proc&.call(info)
       end

--- a/lib/blueprinter-activerecord/missing_preloads_logger.rb
+++ b/lib/blueprinter-activerecord/missing_preloads_logger.rb
@@ -39,7 +39,7 @@ module BlueprinterActiveRecord
     def pre_render(object, blueprint, view, options)
       if object.is_a?(ActiveRecord::Relation) && !object.before_preload_blueprint
         from_code = extract_preloads object
-        from_blueprint = Preloader.preloads(blueprint, view, object.model)
+        from_blueprint = Preloader.preloads(blueprint, view, model: object.model)
         info = PreloadInfo.new(object, from_code, from_blueprint, caller)
         @log_proc&.call(info)
       end

--- a/lib/blueprinter-activerecord/preloader.rb
+++ b/lib/blueprinter-activerecord/preloader.rb
@@ -4,6 +4,7 @@ module BlueprinterActiveRecord
   # A Blueprinter extension to automatically preload a Blueprint view's ActiveRecord associations during render
   class Preloader < Blueprinter::Extension
     include Helpers
+    DEFAULT_MAX_RECURSION = 10
 
     attr_reader :use, :auto, :auto_proc
 
@@ -40,7 +41,7 @@ module BlueprinterActiveRecord
       if object.is_a?(ActiveRecord::Relation) && !object.loaded?
         if object.preload_blueprint_method || auto || auto_proc&.call(object, blueprint, view, options) == true
           object.before_preload_blueprint = extract_preloads object
-          blueprint_preloads = self.class.preloads(blueprint, view, object.model)
+          blueprint_preloads = self.class.preloads(blueprint, view, model: object.model)
           loader = object.preload_blueprint_method || use
           object.public_send(loader, blueprint_preloads)
         else
@@ -62,22 +63,21 @@ module BlueprinterActiveRecord
     #
     # Example:
     #
-    #   preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended, Widget)
+    #   preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended, model: Widget)
     #   q = Widget.where(...).order(...).preload(preloads)
     #
     # @param blueprint [Class] The Blueprint class
     # @param view_name [Symbol] Name of the view in blueprint
-    # @param model [Class] The ActiveRecord model class that blueprint represents
+    # @param model [Class|:polymorphic] The ActiveRecord model class that blueprint represents
+    # @param cycles [Hash<String, Integer>] (internal) Preloading will halt if recursion/cycles gets too high
     # @return [Hash] A Hash containing preload/eager_load/etc info for ActiveRecord
     #
-    def self.preloads(blueprint, view_name, model=nil)
+    def self.preloads(blueprint, view_name, model:, cycles: {})
       view = blueprint.reflections.fetch(view_name)
       preload_vals = view.associations.each_with_object({}) { |(_name, assoc), acc|
         # look for a matching association on the model
-        ref = model ? model.reflections[assoc.name.to_s] : nil
-        if (ref || model.nil?) && !assoc.blueprint.is_a?(Proc)
-          ref_model = ref && !(ref.belongs_to? && ref.polymorphic?) ? ref.klass : nil
-          acc[assoc.name] = preloads(assoc.blueprint, assoc.view, ref_model)
+        if (preload = association_preloads(assoc, model, cycles))
+          acc[assoc.name] = preload
         end
 
         # look for a :preload option on the association
@@ -92,6 +92,39 @@ module BlueprinterActiveRecord
           Helpers.merge_values custom, acc
         end
       }
+    end
+
+    def self.association_preloads(assoc, model, cycles)
+      max_cycles = assoc.options.fetch(:max_recursion, DEFAULT_MAX_RECURSION)
+      if model == :polymorphic
+        if assoc.blueprint.is_a? Proc
+          {}
+        else
+          cycles, count = count_cycles(assoc.blueprint, assoc.view, cycles)
+          count < max_cycles ? preloads(assoc.blueprint, assoc.view, model: model, cycles: cycles) : {}
+        end
+      elsif (ref = model.reflections[assoc.name.to_s])
+        if assoc.blueprint.is_a? Proc
+          {}
+        elsif ref.belongs_to? && ref.polymorphic?
+          cycles, count = count_cycles(assoc.blueprint, assoc.view, cycles)
+          count < max_cycles ? preloads(assoc.blueprint, assoc.view, model: :polymorphic, cycles: cycles) : {}
+        else
+          cycles, count = count_cycles(assoc.blueprint, assoc.view, cycles)
+          count < max_cycles ? preloads(assoc.blueprint, assoc.view, model: ref.klass, cycles: cycles) : {}
+        end
+      end
+    end
+
+    def self.count_cycles(blueprint, view, cycles)
+      id = "#{blueprint.name || blueprint.inspect}/#{view}"
+      cycles = cycles.dup
+      if cycles[id].nil?
+        cycles[id] = 0
+      else
+        cycles[id] += 1
+      end
+      return cycles, cycles[id]
     end
   end
 end

--- a/lib/blueprinter-activerecord/query_methods.rb
+++ b/lib/blueprinter-activerecord/query_methods.rb
@@ -43,7 +43,7 @@ module BlueprinterActiveRecord
 
       if blueprint and view
         # preload right now
-        preloads = Preloader.preloads(blueprint, view, model)
+        preloads = Preloader.preloads(blueprint, view, model: model)
         public_send(use, preloads)
       else
         # preload during render

--- a/lib/blueprinter-activerecord/version.rb
+++ b/lib/blueprinter-activerecord/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BlueprinterActiveRecord
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/lib/tasks/blueprinter_activerecord.rake
+++ b/lib/tasks/blueprinter_activerecord.rake
@@ -14,7 +14,7 @@ namespace :blueprinter do
 
       model = args[:model].constantize
       blueprint = args[:blueprint].constantize
-      preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, args[:view].to_sym, model)
+      preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, args[:view].to_sym, model: model)
       puts pretty preloads
     end
   end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -62,4 +62,12 @@ class ActiveRecordTest < Minitest::Test
     assert_match(/FROM "widgets"/, lines[1])
     assert_nil lines[2]
   end
+
+  def test_invalid_associations_throw
+    assert_raises { Widget.preload(foo).to_a }
+  end
+
+  def test_invalid_associations_under_polymorphic_works
+    Widget.preload(battery1: {foo: :bar}).to_a
+  end
 end

--- a/test/added_preloads_logger_test.rb
+++ b/test/added_preloads_logger_test.rb
@@ -16,8 +16,8 @@ class AddedPreloadsLoggerTest < Minitest::Test
 
     assert_equal({
       :category=>{},
-      :battery1=>{:fake_assoc=>{}, :refurb_plan=>{}},
-      :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}},
+      :battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}},
+      :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}},
       :project=>{:customer=>{}},
     }, BlueprinterActiveRecord::Helpers.extract_preloads(q3))
 
@@ -27,14 +27,16 @@ class AddedPreloadsLoggerTest < Minitest::Test
     assert_equal [
       "battery1",
       "battery1 > fake_assoc",
+      "battery1 > fake_assoc2",
       "battery1 > refurb_plan",
       "battery2",
       "battery2 > fake_assoc",
+      "battery2 > fake_assoc2",
       "battery2 > refurb_plan",
       "project",
       "project > customer",
     ], @info.found.map { |f| f.join " > " }
-    assert_equal 89, @info.percent_found
+    assert_equal 91, @info.percent_found
   end
 
   def test_finds_visible_blueprints

--- a/test/missing_preloads_logger_test.rb
+++ b/test/missing_preloads_logger_test.rb
@@ -18,14 +18,16 @@ class MissingPreloadsLoggerTest < Minitest::Test
     assert_equal [
       "battery1",
       "battery1 > fake_assoc",
+      "battery1 > fake_assoc2",
       "battery1 > refurb_plan",
       "battery2",
       "battery2 > fake_assoc",
+      "battery2 > fake_assoc2",
       "battery2 > refurb_plan",
       "project",
       "project > customer",
     ], @info.found.map { |f| f.join " > " }
-    assert_equal 89, @info.percent_found
+    assert_equal 91, @info.percent_found
   end
 
   def test_finds_visible_blueprints
@@ -50,14 +52,16 @@ class MissingPreloadsLoggerTest < Minitest::Test
     assert_equal [
       "battery1",
       "battery1 > fake_assoc",
+      "battery1 > fake_assoc2",
       "battery1 > refurb_plan",
       "battery2",
       "battery2 > fake_assoc",
+      "battery2 > fake_assoc2",
       "battery2 > refurb_plan",
       "project",
       "project > customer",
     ], @info.found.map { |f| f.join " > " }
-    assert_equal 89, @info.percent_found
+    assert_equal 91, @info.percent_found
   end
 
   def test_ignores_queries_from_preloader_ext

--- a/test/preloader_extension_test.rb
+++ b/test/preloader_extension_test.rb
@@ -105,7 +105,7 @@ class PreloaderExtensionTest < Minitest::Test
       preload_blueprint(WidgetBlueprint, :extended).
       strict_loading
 
-    assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+    assert_equal [{:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
   def test_blueprinter_preload_now_with_existing_preloads
@@ -129,7 +129,7 @@ class PreloaderExtensionTest < Minitest::Test
 
     assert ext.auto
     assert_equal :preload, ext.use
-    assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+    assert_equal [{:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
   def test_auto_preload_with_existing_preloads
@@ -153,7 +153,7 @@ class PreloaderExtensionTest < Minitest::Test
 
     assert ext.auto
     assert_equal :preload, ext.use
-    assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+    assert_equal [{:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
   def test_auto_preload_with_block_true
@@ -166,7 +166,7 @@ class PreloaderExtensionTest < Minitest::Test
 
     refute_nil ext.auto_proc
     assert_equal :preload, ext.use
-    assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
+    assert_equal [{:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:preload]
   end
 
   def test_auto_preload_with_block_false
@@ -192,6 +192,6 @@ class PreloaderExtensionTest < Minitest::Test
 
     assert ext.auto
     assert_equal :includes, ext.use
-    assert_equal [{:battery1=>{:fake_assoc=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:includes]
+    assert_equal [{:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :project=>{:customer=>{}}}], q.values[:includes]
   end
 end

--- a/test/preloads_test.rb
+++ b/test/preloads_test.rb
@@ -4,34 +4,28 @@ require 'test_helper'
 
 class PreloadsTest < Minitest::Test
   def test_preload_with_model
-    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended, Widget)
+    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended, model: Widget)
     assert_equal({
       category: {},
       project: {customer: {}},
-      battery1: {refurb_plan: {}, fake_assoc: {}},
-      battery2: {refurb_plan: {}, fake_assoc: {}},
+      battery1: {refurb_plan: {}, fake_assoc: {}, fake_assoc2: {}},
+      battery2: {refurb_plan: {}, fake_assoc: {}, fake_assoc2: {}},
     }, preloads)
   end
 
   def test_preload_with_model_with_custom_names
-    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :short, Widget)
+    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :short, model: Widget)
     assert_equal({
       category: {},
       project: {customer: {}},
-      battery1: {refurb_plan: {}, fake_assoc: {}},
-      battery2: {refurb_plan: {}, fake_assoc: {}},
+      battery1: {refurb_plan: {}, fake_assoc: {}, fake_assoc2: {}},
+      battery2: {refurb_plan: {}, fake_assoc: {}, fake_assoc2: {}},
     }, preloads)
   end
 
-  def test_preload_sans_model
-    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended)
-    assert_equal({
-      parts: {},
-      category: {},
-      project: {customer: {}},
-      battery1: {refurb_plan: {}, fake_assoc: {}},
-      battery2: {refurb_plan: {}, fake_assoc: {}},
-    }, preloads)
+  def test_preload_with_polymorphic_model
+    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :extended, model: :polymorphic)
+    assert_equal({:battery1=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :battery2=>{:fake_assoc=>{}, :fake_assoc2=>{}, :refurb_plan=>{}}, :category=>{}, :parts=>{}, :project=>{:customer=>{}}}, preloads)
   end
 
   def test_preload_with_annotated_fields
@@ -45,7 +39,7 @@ class PreloadsTest < Minitest::Test
       end
     end
 
-    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, Widget)
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, model: Widget)
     assert_equal({
       project: {},
       category: {},
@@ -64,11 +58,75 @@ class PreloadsTest < Minitest::Test
       end
     end
 
-    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, Widget)
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, model: Widget)
     assert_equal({
       project: {},
       category: {},
       battery1: {refurb_plan: {}},
     }, preloads)
+  end
+
+  def test_preload_with_recursive_blueprint_default_max
+    blueprint = Class.new(Blueprinter::Base) do
+      association :children, blueprint: self
+      association :widgets, blueprint: WidgetBlueprint
+    end
+
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, model: Category)
+    expected = BlueprinterActiveRecord::Preloader::DEFAULT_MAX_RECURSION.times.
+      reduce({widgets: {}, children: {}}) { |acc, _|
+        {widgets: {}, children: acc}
+      }
+    assert_equal(expected, preloads)
+  end
+
+  def test_preload_with_recursive_blueprint_custom_max
+    blueprint = Class.new(Blueprinter::Base) do
+      association :children, blueprint: self, max_recursion: 5
+      association :widgets, blueprint: WidgetBlueprint
+    end
+
+    preloads = BlueprinterActiveRecord::Preloader.preloads(blueprint, :default, model: Category)
+    expected = 5.times.reduce({widgets: {}, children: {}}) { |acc, _|
+      {widgets: {}, children: acc}
+    }
+    assert_equal(expected, preloads)
+  end
+
+  def test_preload_with_cyclic_blueprints_default_max
+    preloads = BlueprinterActiveRecord::Preloader.preloads(CategoryBlueprint, :cyclic, model: Category)
+    expected = BlueprinterActiveRecord::Preloader::DEFAULT_MAX_RECURSION.times.
+      reduce({widgets: {}}) { |acc, _|
+        {widgets: {category: acc}}
+      }
+    assert_equal(expected, preloads)
+  end
+
+  def test_halts_on_dynamic_blueprint
+    preloads = BlueprinterActiveRecord::Preloader.preloads(WidgetBlueprint, :dynamic, model: Widget)
+    assert_equal({category: {}}, preloads)
+  end
+
+  def test_cycle_detection1
+    cycles, count = BlueprinterActiveRecord::Preloader.count_cycles(CategoryBlueprint, :default, {})
+    assert_equal({"CategoryBlueprint/default" => 0}, cycles)
+    assert_equal 0, count
+  end
+
+  def test_cycle_detection2
+    cycles, count = BlueprinterActiveRecord::Preloader.count_cycles(CategoryBlueprint, :default, {
+      "CategoryBlueprint/default" => 0,
+    })
+    assert_equal({"CategoryBlueprint/default" => 1}, cycles)
+    assert_equal 1, count
+  end
+
+  def test_cycle_detection3
+    cycles, count = BlueprinterActiveRecord::Preloader.count_cycles(WidgetBlueprint, :default, {
+      "WidgetBlueprint/default" => 9,
+      "CategoryBlueprint/foo" => 8,
+    })
+    assert_equal({"WidgetBlueprint/default" => 10, "CategoryBlueprint/foo" => 8}, cycles)
+    assert_equal 10, count
   end
 end

--- a/test/support/active_record_models.rb
+++ b/test/support/active_record_models.rb
@@ -12,6 +12,9 @@ end
 
 class Category < ActiveRecord::Base
   belongs_to :company
+  belongs_to :parent, class_name: "Category", optional: true
+  has_many :children, foreign_key: :parent_id, class_name: "Category", inverse_of: :parent
+  has_many :widgets
 end
 
 class Widget < ActiveRecord::Base

--- a/test/support/active_record_schema.rb
+++ b/test/support/active_record_schema.rb
@@ -15,6 +15,7 @@ module Schema
 
       create_table :categories do |t|
         t.string :name, null: false
+        t.integer :parent_id
         t.text :description
       end
 

--- a/test/support/blueprints.rb
+++ b/test/support/blueprints.rb
@@ -29,6 +29,14 @@ class CategoryBlueprint < Blueprinter::Base
   view :extended do
     fields :id, :name, :description
   end
+
+  view :nested do
+    association :children, blueprint: CategoryBlueprint, view: :nested
+  end
+
+  view :cyclic do
+    association :widgets, blueprint: WidgetBlueprint, view: :cyclic
+  end
 end
 
 class RefurbPlanBlueprint < Blueprinter::Base
@@ -84,5 +92,12 @@ class WidgetBlueprint < Blueprinter::Base
     association :category, blueprint: CategoryBlueprint, view: :extended
     association :project, blueprint: ProjectBlueprint, view: :extended
   end
-end
 
+  view :cyclic do
+    association :category, blueprint: CategoryBlueprint, view: :cyclic
+  end
+
+  view :dynamic do
+    association :category, blueprint: -> { CategoryBlueprint }
+  end
+end


### PR DESCRIPTION
A fix for #13, where we get infinite recursion when a blueprint has an association to `self`, or when it's part of a cycle. Now it will halt preloading after 10 cycles. If that's not enough, it can be increased:

```ruby
class CategoryBlueprint < Blueprinter::Base
  field :name
  association :children, blueprint: self, max_recursion: 20
end
```