### PR TITLE
Fix tests running with old versions of ActiveSupport

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -10,8 +10,10 @@ end
 
 appraise "ar-7.0" do
   gem "activerecord", "~> 7.0.8"
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise "ar-6.1" do
   gem "activerecord", "~> 6.1.7"
+  gem "concurrent-ruby", "1.3.4"
 end

--- a/gemfiles/ar_6.1.gemfile
+++ b/gemfiles/ar_6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.7"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ar_7.0.gemfile
+++ b/gemfiles/ar_7.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.8"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"


### PR DESCRIPTION
Pins concurrent-ruby to 1.3.4 for older versions of ActiveSupport: https://www.devgem.io/posts/resolving-the-loggerthreadsafelevel-error-in-rails-after-bundle-update