### PR TITLE
Drop Ruby 3.1 and bump minitest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,26 +27,3 @@ jobs:
           bundle exec appraisal install
       - name: Run tests
         run: bundle exec appraisal rake test
-
-  test-3_1:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        ruby: ["3.1"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Installing dependencies
-        run: |
-          bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
-          bundle exec appraisal ar-7.1 bundle install --path=vendor/bundle
-          bundle exec appraisal ar-7.2 bundle install --path=vendor/bundle
-      - name: Run tests
-        run: |
-          bundle exec appraisal ar-7.1 rake test
-          bundle exec appraisal ar-7.2 rake test

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem 'appraisal', '~> 2.5'
 gem 'database_cleaner', '~> 2.0'
-gem 'minitest', '~> 5.0'
+gem 'minitest', '~> 6.0'
 gem 'rake', '~> 13.0'
 gem 'sqlite3', '~> 2.6'
 gem 'ostruct', '~> 0.6'


### PR DESCRIPTION
- Bump minitest from 5 -> 6
- Drop testing for Ruby 3.1 (incompatible with minitest 6 and EOL for 11 months)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/blueprinter-activerecord/blob/main/CONTRIBUTING.md)
* [x] My build is green
